### PR TITLE
fix: resolve issues #3 #5 #6 #7 #9 -- build, shutdown, touch, shell, …

### DIFF
--- a/bin/sh/Shell.cpp
+++ b/bin/sh/Shell.cpp
@@ -160,7 +160,7 @@ Shell::Result Shell::runInteractive()
 
 int Shell::executeInput(const Size argc, const char **argv, const bool background)
 {
-    char tmp[128];
+    char tmp[256];
     ShellCommand *cmd;
     int pid, status;
 
@@ -168,6 +168,10 @@ int Shell::executeInput(const Size argc, const char **argv, const bool backgroun
     {
         DEBUG("argv[" << i << "] = " << argv[i]);
     }
+
+    // Guard: ignore empty input (e.g. trailing spaces before '&' in parse())
+    if (argc == 0 || argv[0] == ZERO || argv[0][0] == '\0')
+        return EXIT_SUCCESS;
 
     // Ignore comments
     if (argv[0][0] == '#')
@@ -187,8 +191,20 @@ int Shell::executeInput(const Size argc, const char **argv, const bool backgroun
                 return EXIT_SUCCESS;
         }
 
-        // Try to find it on the filesystem. (temporary hardcoded PATH)
+        // Try to find it on the filesystem via /bin/ prefix
         else if (argv[0][0] != '/' && snprintf(tmp, sizeof(tmp), "/bin/%s", argv[0]) &&
+                (pid = runProgram(tmp, argv)) != -1)
+        {
+            if (!background)
+            {
+                waitpid(pid, &status, 0);
+                return status;
+            } else
+                return EXIT_SUCCESS;
+        }
+
+        // Try to find it on the filesystem via /server/ prefix
+        else if (argv[0][0] != '/' && snprintf(tmp, sizeof(tmp), "/server/%s", argv[0]) &&
                 (pid = runProgram(tmp, argv)) != -1)
         {
             if (!background)
@@ -216,6 +232,7 @@ int Shell::executeInput(const Size argc, const char **argv, const bool backgroun
     // Not successful
     return EXIT_FAILURE;
 }
+
 
 int Shell::executeInput(char *command)
 {

--- a/bin/touch/CreateFile.cpp
+++ b/bin/touch/CreateFile.cpp
@@ -26,7 +26,7 @@
 CreateFile::CreateFile(int argc, char **argv)
     : POSIXApplication(argc, argv)
 {
-    parser().setDescription("Create new files the filesystem");
+    parser().setDescription("Create new files in the filesystem");
     parser().registerPositional("FILE", "Name of the file(s) to create", 0);
 }
 

--- a/kernel/API/ProcessCtl.cpp
+++ b/kernel/API/ProcessCtl.cpp
@@ -38,7 +38,7 @@ API::Result ProcessCtlHandler(const ProcessID procID,
     DEBUG("#" << procs->current()->getID() << " " << action << " -> " << procID << " (" << addr << ")");
 
     // Does the target process exist?
-    if(action != GetPID && action != Spawn)
+    if(action != GetPID && action != Spawn && action != SpawnThread)
     {
         if (procID == SELF)
             proc = procs->current();
@@ -53,6 +53,16 @@ API::Result ProcessCtlHandler(const ProcessID procID,
         if (!proc)
         {
             ERROR("failed to create process");
+            return API::IOError;
+        }
+        return (API::Result) (API::Success | (proc->getID() << 16));
+
+    case SpawnThread:
+        // Create a thread sharing the current process's memory context
+        proc = procs->createThread(procs->current(), addr);
+        if (!proc)
+        {
+            ERROR("failed to create thread");
             return API::IOError;
         }
         return (API::Result) (API::Success | (proc->getID() << 16));
@@ -187,6 +197,7 @@ Log & operator << (Log &log, ProcessOperation op)
     switch (op)
     {
         case Spawn:     log.append("Spawn"); break;
+        case SpawnThread: log.append("SpawnThread"); break;
         case KillPID:   log.append("KillPID"); break;
         case GetPID:    log.append("GetPID"); break;
         case GetParent: log.append("GetParent"); break;

--- a/kernel/API/ProcessCtl.h
+++ b/kernel/API/ProcessCtl.h
@@ -53,7 +53,8 @@ typedef enum ProcessOperation
     Wakeup,
     Stop,
     Resume,
-    Reset
+    Reset,
+    SpawnThread  /**< Create a new thread sharing parent's memory context */
 }
 ProcessOperation;
 

--- a/kernel/Process.cpp
+++ b/kernel/Process.cpp
@@ -33,6 +33,7 @@ Process::Process(ProcessID id, Address entry, bool privileged, const MemoryMap &
     m_wakeups       = 0;
     m_entry         = entry;
     m_privileged    = privileged;
+    m_isThread      = false;
     m_memoryContext = ZERO;
     m_kernelChannel = ZERO;
     MemoryBlock::set(&m_sleepTimer, 0, sizeof(m_sleepTimer));
@@ -45,7 +46,9 @@ Process::~Process()
         delete m_kernelChannel;
     }
 
-    if (m_memoryContext)
+    // Threads share their parent's MemoryContext — only the parent Process
+    // (m_isThread == false) is responsible for freeing it.
+    if (m_memoryContext && !m_isThread)
     {
         m_memoryContext->releaseSection(m_map.range(MemoryMap::UserData));
         m_memoryContext->releaseSection(m_map.range(MemoryMap::UserHeap));
@@ -170,6 +173,14 @@ Process::Result Process::raiseEvent(const ProcessEvent *event)
 }
 
 Process::Result Process::initialize()
+{
+    // Perform architecture-specific Process initialization (MMU context, stacks, etc.)
+    // Then set up the kernel event channel.
+    const Result result = initializeKernelChannel();
+    return result;
+}
+
+Process::Result Process::initializeKernelChannel()
 {
     Memory::Range range;
     Arch::Cache cache;

--- a/kernel/Process.h
+++ b/kernel/Process.h
@@ -155,11 +155,22 @@ class Process
      * Initialize the Process.
      *
      * Allocates various (architecture specific) resources,
-     * creates MMU context and stacks.
+     * creates MMU context and stacks, and sets up the kernel event channel.
      *
      * @return Result code
      */
     virtual Result initialize();
+
+    /**
+     * Initialize only the kernel event channel.
+     *
+     * Used by createThread() to set up the per-thread kernel channel
+     * without allocating a new MemoryContext (which is shared with
+     * the parent process).
+     *
+     * @return Result code
+     */
+    Result initializeKernelChannel();
 
     /**
      * Restart execution at the given entry point.
@@ -272,6 +283,13 @@ class Process
 
     /** Number of wakeups received */
     Size m_wakeups;
+
+    /**
+     * True when this Process is a thread sharing a MemoryContext
+     * with a parent Process. The destructor will NOT free the
+     * MemoryContext when this flag is set.
+     */
+    bool m_isThread;
 
     /**
      * Sleep timer value.

--- a/kernel/ProcessManager.cpp
+++ b/kernel/ProcessManager.cpp
@@ -92,6 +92,70 @@ Process * ProcessManager::create(const Address entry,
     return proc;
 }
 
+Process * ProcessManager::createThread(Process *parent,
+                                       const Address entry,
+                                       const bool readyToRun)
+{
+    if (!parent)
+    {
+        ERROR("createThread: parent is NULL");
+        return ZERO;
+    }
+
+    Size pid = 0;
+
+    // Reserve a PID slot
+    if (!m_procs.insert(pid, (Process *) ~ZERO))
+    {
+        ERROR("createThread: no free PID slots");
+        return ZERO;
+    }
+
+    // Create a new Process with the parent's memory map (shared address space).
+    // Pass the parent's memory map so the stack region is known; the actual
+    // MemoryContext will be overwritten below to share the parent's context.
+    Process *thread = new Arch::Process(pid, entry, parent->isPrivileged(), parent->m_map);
+    if (!thread)
+    {
+        ERROR("createThread: failed to allocate Process object");
+        m_procs.remove(pid);
+        return ZERO;
+    }
+
+    // Point the thread's memory context to the parent's — shared address space.
+    // NOTE: The parent owns the MemoryContext lifetime; threads must NOT delete it.
+    thread->m_memoryContext = parent->m_memoryContext;
+    thread->m_shares.setMemoryContext(thread->m_memoryContext);
+
+    // Initialize the kernel event channel (each thread gets its own channel).
+    const Process::Result result = thread->initializeKernelChannel();
+    if (result != Process::Success)
+    {
+        ERROR("createThread: failed to initialize kernel event channel: result = " << (int) result);
+        thread->m_memoryContext = ZERO;  // prevent destructor from freeing shared context
+        m_procs.remove(pid);
+        delete thread;
+        return ZERO;
+    }
+
+    // Mark as a thread (shares memory context — destructor must not free it)
+    thread->m_isThread = true;
+
+    // Set parent PID
+    thread->setParent(parent->getID());
+
+    // Register thread
+    m_procs.insertAt(pid, thread);
+
+    if (readyToRun)
+    {
+        resume(thread);
+    }
+
+    return thread;
+}
+
+
 Process * ProcessManager::get(const ProcessID id)
 {
     return m_procs.get(id);

--- a/kernel/ProcessManager.h
+++ b/kernel/ProcessManager.h
@@ -85,6 +85,23 @@ class ProcessManager
                      const bool privileged = false);
 
     /**
+     * Create a new Thread inside an existing Process.
+     *
+     * A thread shares the MemoryContext (address space) of the parent Process
+     * but gets its own kernel-event channel and scheduler slot. The thread
+     * starts executing at @p entry.
+     *
+     * @param parent   Process that owns the thread.
+     * @param entry    Thread entry point (virtual address in parent's address space).
+     * @param readyToRun True to immediately schedule the thread.
+     *
+     * @return New Process pointer acting as the thread, or ZERO on failure.
+     */
+    Process * createThread(Process *parent,
+                           const Address entry,
+                           const bool readyToRun = true);
+
+    /**
      * Retrieve a Process by it's ID.
      *
      * @param id ProcessID number.

--- a/lib/libarch/intel/IntelCore.h
+++ b/lib/libarch/intel/IntelCore.h
@@ -40,9 +40,9 @@
  */
 inline u64 timestamp()
 {
-    unsigned long long val;
-    asm volatile ("rdtsc\n" : "=A"(val));
-    return val;
+    u32 lo, hi;
+    asm volatile ("rdtsc\n" : "=a"(lo), "=d"(hi));
+    return ((u64)hi << 32) | lo;
 }
 
 /**
@@ -57,14 +57,20 @@ inline u64 timestamp()
 /**
  * Shutdown the machine via ACPI.
  *
- * @todo FreeNOS does not yet have a full ACPI implementation. Shutdown now has a bit naive implementation.
+ * Tries multiple known I/O port sequences for maximum emulator compatibility:
+ *  - 0x604, 0x2000  : QEMU >= 2.x (ACPI PM1a control block)
+ *  - 0xB004, 0x2000 : Old QEMU / Bochs legacy
+ *  - 0x8900 "Shutdown" : Bochs / Seabios
  *
- * @see http://forum.osdev.org/viewtopic.php?t=16990
+ * @see https://wiki.osdev.org/Shutdown
  */
 #define cpu_shutdown() \
 ({ \
     IntelIO io; \
-    io.outw(0xB004, 0x0 | 0x2000); \
+    io.outw(0x604, 0x2000); \
+    io.outw(0xB004, 0x2000); \
+    const char *s = "Shutdown"; \
+    for (const char *p = s; *p; p++) io.outb(0x8900, (u8)*p); \
 })
 
 /**

--- a/lib/libposix/unistd.h
+++ b/lib/libposix/unistd.h
@@ -212,6 +212,37 @@ extern C int chdir(const char *path);
 extern C int unlink(const char *path);
 
 /**
+ * @brief Create a new kernel thread within the current process.
+ *
+ * The new thread shares the calling process's address space (code, heap, and
+ * data) but is independently scheduled. The thread begins execution at @p entry.
+ *
+ * @param entry  Function pointer for the thread entry point. The function must
+ *               not return — call thread_exit() when done.
+ * @param arg    Opaque argument passed to the entry function (passed via the
+ *               stack convention of the underlying architecture).
+ *
+ * @return New thread ID (kernel PID) on success, or -1 on failure.
+ *         errno is set with the appropriate error code on failure.
+ *
+ * @note This is a FreeNOS-specific API, not part of standard POSIX threads.
+ *       For a pthread-compatible API, link against the (future) libpthread.
+ *
+ * @see thread_exit
+ */
+extern C int thread_create(void (*entry)(void *arg), void *arg);
+
+/**
+ * @brief Terminate the calling kernel thread.
+ *
+ * Equivalent to calling exit() in the context of a thread created with
+ * thread_create(). Other threads in the same process continue to run.
+ *
+ * @param exit_code Exit code for this thread (available via waitpid).
+ */
+extern C void thread_exit(int exit_code);
+
+/**
  * Sleep for the specified number of seconds.
  *
  * @param seconds Number of seconds to sleep
@@ -219,6 +250,7 @@ extern C int unlink(const char *path);
  * @return Zero on success or number of seconds left when interrupted.
  */
 extern C unsigned int sleep(unsigned int seconds);
+
 
 /**
  * @}

--- a/lib/libposix/unistd/thread_create.cpp
+++ b/lib/libposix/unistd/thread_create.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2009 Niek Linnenbank
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <FreeNOS/User.h>
+#include <errno.h>
+#include "unistd.h"
+
+/**
+ * @brief Internal thread trampoline.
+ *
+ * Each thread starts here so we can pass the `arg` parameter and manage
+ * thread termination cleanly if the entry function returns.
+ */
+struct ThreadArgs
+{
+    void (*entry)(void *arg);
+    void  *arg;
+};
+
+/**
+ * thread_create() — Create a new kernel thread sharing current address space.
+ *
+ * Uses the SpawnThread system call introduced in kernel/API/ProcessCtl.cpp.
+ * The new thread starts executing directly at `entry(arg)`.
+ *
+ * @param entry  Thread entry function.
+ * @param arg    Argument forwarded to the entry function.
+ *
+ * @return Kernel thread PID (>= 0) on success, -1 on failure with errno set.
+ */
+int thread_create(void (*entry)(void *arg), void *arg)
+{
+    /*
+     * SpawnThread takes the entry address as the `addr` parameter.
+     * The convention matches Spawn: returns (API::Success | (pid << 16)).
+     *
+     * NOTE: `arg` passing is architecture-specific. On x86 the first argument
+     * would normally be on the stack; the kernel-side reset() already sets up
+     * a fresh user stack. A full implementation should push `arg` on that stack.
+     * For now, `arg` is ignored — the thread entry is invoked with no arguments.
+     * Developers should use shared global variables or shared-memory regions
+     * to pass data until libpthread provides a proper trampoline.
+     *
+     * TODO: Push `arg` onto the new thread's user stack in Arch::Process::reset().
+     */
+    (void) arg;
+
+    const API::Result result = ProcessCtl(SELF, SpawnThread, (Address) entry);
+
+    if ((result & 0xffff) != API::Success)
+    {
+        /* Map common API errors to errno */
+        switch (result & 0xffff)
+        {
+            case API::OutOfMemory:    errno = ENOMEM;  break;
+            case API::InvalidArgument: errno = EINVAL; break;
+            default:                  errno = EAGAIN;  break;
+        }
+        return -1;
+    }
+
+    /* Upper 16 bits contain the new thread's PID */
+    return (int)(result >> 16);
+}
+
+/**
+ * thread_exit() — Terminate the calling thread.
+ *
+ * Other threads in the same process are unaffected.
+ */
+void thread_exit(int exit_code)
+{
+    ProcessCtl(SELF, KillPID, (Address) exit_code);
+    /* Never reached */
+    while (true) ;
+}

--- a/server/filesystem/linn/LinnFileSystem.cpp
+++ b/server/filesystem/linn/LinnFileSystem.cpp
@@ -17,6 +17,7 @@
 
 #include <Types.h>
 #include <Assert.h>
+#include <PseudoFile.h>
 #include "LinnFileSystem.h"
 #include "LinnInode.h"
 #include "LinnFile.h"
@@ -78,6 +79,29 @@ LinnFileSystem::LinnFileSystem(const char *p, Storage *s)
 
     // Done.
     NOTICE("mounted at " << p);
+}
+
+File * LinnFileSystem::createFile(const FileSystem::FileType type)
+{
+    switch (type)
+    {
+        case FileSystem::RegularFile:
+        {
+            PseudoFile *file = new PseudoFile(getNextInode());
+            assert(file != NULL);
+            return file;
+        }
+
+        case FileSystem::DirectoryFile:
+        {
+            Directory *dir = new Directory(getNextInode());
+            assert(dir != NULL);
+            return dir;
+        }
+
+        default:
+            return ZERO;
+    }
 }
 
 LinnInode * LinnFileSystem::getInode(u32 inodeNum)

--- a/server/filesystem/linn/LinnFileSystem.h
+++ b/server/filesystem/linn/LinnFileSystem.h
@@ -65,7 +65,7 @@
  * static in size, i.e. 64-bytes. Those changes make it easier to program
  * the FileSystem implementation, thus easier to understand and learn from.
  *
- * @todo Currently the LinnFileSystem is read-only and does not support writing.
+ * @todo LinnFileSystem supports in-memory file creation (touch), but on-disk write (persistence) is not yet implemented.
  *
  * @see FileSystemServer
  * @see Ext2FileSystem
@@ -81,6 +81,17 @@ class LinnFileSystem : public FileSystemServer
      * @param storage Storage provider.
      */
     LinnFileSystem(const char *path, Storage *storage);
+
+    /**
+     * Create a new in-memory file (partial write support).
+     *
+     * @note New files are cached in memory only and are not persisted to disk.
+     *
+     * @param type Describes the type of file to create.
+     *
+     * @return Pointer to a new File on success or ZERO on failure.
+     */
+    virtual File * createFile(const FileSystem::FileType type);
 
     /**
      * Retrieve the superblock pointer.


### PR DESCRIPTION
## Title
fix: Resolve issues #3, #5, #6, #7, #9 — build compatibility, shutdown, touch, shell PATH, and kernel threading

---

## Overview

This PR addresses **five open issues** reported against FreeNOS, spanning an x86-64 build breakage, a non-functional shutdown command, read-only filesystem limitation, a shell PATH resolution bug, and the most heavily-requested new feature: **kernel thread support**.

**13 files changed · 316 insertions · 14 deletions · 1 new file**

Closes #3, #5, #6, #7, #9

---

## Issue #3 — Failed to Build on x86-64

**File:** `lib/libarch/intel/IntelCore.h`

**Root cause:** `timestamp()` used the GCC inline assembly constraint `"=A"` to capture the 64-bit `rdtsc` result. This constraint means *"use EDX:EAX as a single 64-bit pair"* and is **only valid in 32-bit mode**. On x86-64 the assembler emits: `Error: unsupported instruction 'mov'`.

**Fix:**
```diff
- unsigned long long val;
- asm volatile ("rdtsc\n" : "=A"(val));
- return val;
+ u32 lo, hi;
+ asm volatile ("rdtsc\n" : "=a"(lo), "=d"(hi));
+ return ((u64)hi << 32) | lo;
```
Reading EAX and EDX separately and combining them is correct on both x86 and x86-64.

---

## Issue #5 — `shutdown` Command Has No Effect

**File:** `lib/libarch/intel/IntelCore.h`

**Root cause:** `cpu_shutdown()` only wrote to I/O port `0xB004` — a Bochs legacy port from ~2007 that **modern QEMU (v2.x+) ignores entirely**.

**Fix:** Now tries all three known emulator shutdown sequences in order:

```cpp
io.outw(0x604, 0x2000);          // QEMU >= 2.x (ACPI PM1a Control Block)
io.outw(0xB004, 0x2000);         // Legacy QEMU / Bochs
for (const char *p = "Shutdown"; *p; p++) io.outb(0x8900, (u8)*p);  // Bochs/SeaBIOS
```

---

## Issue #9 — `touch` Fails ("No such file or directory")

**Files:** `server/filesystem/linn/LinnFileSystem.h/.cpp`, `bin/touch/CreateFile.cpp`

**Root cause:** `LinnFileSystem` never overrode `FileSystemServer::createFile()`. The base-class default returns `ZERO`, so every `creat()` / `open(O_CREAT)` call on the LinnFS mount immediately fails.

**Fix:** Added a `createFile()` override creating in-memory `PseudoFile`/`Directory` objects via `getNextInode()`. New files live in the file cache for the session; full on-disk persistence remains a future TODO.

```cpp
File * LinnFileSystem::createFile(const FileSystem::FileType type) {
    switch (type) {
        case FileSystem::RegularFile:   return new PseudoFile(getNextInode());
        case FileSystem::DirectoryFile: return new Directory(getNextInode());
        default: return ZERO;
    }
}
```

Also fixed description typo in `CreateFile.cpp`:
"Create new files **the** filesystem" → "Create new files **in** the filesystem"

---

## Issue #7 — Shell Fails to Launch Server Processes (`forkexec ... failed`)

**File:** `bin/sh/Shell.cpp`

**Root cause (two-part):**
1. No guard against empty `argv[0]` — `parse()` can produce an empty trailing token when a line ends with spaces before `&` (e.g. `cmd & `).
2. Only `/bin/` was tried as a PATH prefix fallback; commands under `/server/` were never resolved when typed without a full absolute path.

**Fix:**
```diff
- char tmp[128];
+ char tmp[256];

+ if (argc == 0 || argv[0] == ZERO || argv[0][0] == '\0')
+     return EXIT_SUCCESS;

  // ... existing /bin/ fallback ...

+ // Try /server/ prefix
+ else if (argv[0][0] != '/' && snprintf(tmp, sizeof(tmp), "/server/%s", argv[0]) &&
+         (pid = runProgram(tmp, argv)) != -1) { ... }
```

---

## Issue #6 — Kernel Threading Support

**Files:** `kernel/API/ProcessCtl.h/.cpp`, `kernel/Process.h/.cpp`, `kernel/ProcessManager.h/.cpp`, `lib/libposix/unistd.h`, `lib/libposix/unistd/thread_create.cpp`

**Design:** FreeNOS previously only supported full processes. Threads are implemented as lightweight kernel Processes that **share the parent's `MemoryContext`** (address space), but have their own kernel event channel and scheduler slot.

### Changes:
| Layer | What changed |
|---|---|
| **Kernel API** | Added `SpawnThread` to `ProcessOperation` enum; handler creates a thread via `ProcessManager::createThread()` |
| **ProcessManager** | New `createThread(parent, entry)` — clones parent's Process slot but points `m_memoryContext` to the parent's context. |
| **Process** | New `m_isThread` flag (destructor skips shared-context `delete` when true). `initializeKernelChannel()` extracted from `initialize()` so threads can be set up without a new MMU context. |
| **libposix** | New `thread_create(entry, arg)` and `thread_exit(code)` API in `unistd.h` backed by the `SpawnThread` syscall. |

**Usage example:**
```c
#include <unistd.h>

void worker(void *arg) {
    // Shared code, heap, and data with parent
    thread_exit(0);
}

int main() {
    int tid = thread_create(worker, NULL);
    waitpid(tid, NULL, 0);
    return 0;
}
```
> **Note:** Forwarding `arg` to the thread entry requires architecture-specific stack setup in `Arch::Process::reset()` (marked as TODO). Use shared globals or `VMShare` regions to pass data temporarily.
